### PR TITLE
Added test for s_number and fixed IC's for test

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphKerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphKerrSchild.cpp
@@ -38,9 +38,9 @@ template <typename Frame, typename DataType>
 tnsr::I<DataType, 3, Frame> spatial_coords(
     const DataType& used_for_size) noexcept {
   auto x = make_with_value<tnsr::I<DataType, 3, Frame>>(used_for_size, 0.0);
-  get<0>(x) = 2.;
-  get<1>(x) = 0.;
-  get<2>(x) = 1.;
+  get<0>(x) = 1.;
+  get<1>(x) = 2.;
+  get<2>(x) = 3.;
   return x;
 }
 
@@ -169,7 +169,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.SphKerrSchild",
   const double used_for_size_double = used_for_size.size();
   const double mass = 1.01;
   const std::array<double, 3> spin{{0.0, 0.0, .5}};
-  const std::array<double, 3> center{{0.0, 0.0, 1.0}};
+  const std::array<double, 3> center{{1.0, 1.0, 1.0}};
   const auto x = spatial_coords<Frame::Inertial>(used_for_size);
   const double null_vector_0 = -1.0;
   // const double t = 1.0;
@@ -270,6 +270,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.SphKerrSchild",
       make_not_null(&s_number), make_not_null(&cache),
       gr::Solutions::SphKerrSchild::internal_tags::internal_tags::s_number<
           DataVector>{});
+
+  auto expected_s_number =
+      make_with_value<Scalar<DataVector>>(s_number, 5.20402);
+  CHECK_ITERABLE_APPROX(s_number, expected_s_number);
 
   // matrix_G2 test
   tnsr::Ij<DataVector, 3, Frame::Inertial> matrix_G2{1, 0.};


### PR DESCRIPTION
## Proposed changes
Added the test for s_number choosing the CHECK_ITERABLE_APPROX macro. Fixed IC's for our system so that the values we calculate by hand can match those calculated by our code.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
