### PR TITLE
Added explicit test for s_number

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphKerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphKerrSchild.cpp
@@ -294,6 +294,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.SphKerrSchild",
       gr::Solutions::SphKerrSchild::internal_tags::internal_tags::s_number<
           DataVector>{});
 
+  // Explicit s_number test
+  auto expected_s_number =
+    make_with_value<Scalar<DataVector>>(s_number, 14.2914571428571428);
+  CHECK_ITERABLE_APPROX(s_number, expected_s_number);
+
   // matrix_G2 test
   tnsr::Ij<DataVector, 3, Frame::Inertial> matrix_G2{1, 0.};
   sks_computer(make_not_null(&matrix_G2), make_not_null(&cache),


### PR DESCRIPTION
## Proposed changes
Added an explicit test for `s_number` with hand-calculated values.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
