### PR TITLE
Added explicit test for G1_dot_x

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphKerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphKerrSchild.cpp
@@ -364,6 +364,13 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.SphKerrSchild",
       gr::Solutions::SphKerrSchild::internal_tags::G1_dot_x<DataVector,
                                                             Frame::Inertial>{});
 
+  // Explicit G1_dot_x test
+  tnsr::I<DataVector, 3, Frame::Inertial> expected_G1_dot_x{3, 0.};
+  expected_G1_dot_x.get(0) = -0.0020977902866797763;
+  expected_G1_dot_x.get(1) = -0.00038141641575995845;
+  expected_G1_dot_x.get(2) = 0.0013349574551598563;
+  CHECK_ITERABLE_APPROX(G1_dot_x, expected_G1_dot_x);
+
   // G2_dot_x test
   tnsr::i<DataVector, 3, Frame::Inertial> G2_dot_x{3, 0.};
   sks_computer(


### PR DESCRIPTION
## Proposed changes

Added explicit test for `G1_dot_x`

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
